### PR TITLE
[Q/R] Only reexport headers if version is set

### DIFF
--- a/kernel_headers.go
+++ b/kernel_headers.go
@@ -22,16 +22,15 @@ func qtiKernelHeadersDefaultsFactory() android.Module {
 
 func qtiKernelHeadersDefaults(ctx android.LoadHookContext) {
 	version := ctx.Config().VendorConfig("qti_kernel_headers").String("version")
+	qtimodule := fmt.Sprintf("qti_kernel_headers_%s", version)
 
 	p := struct {
 		Export_header_lib_headers []string
-		Header_libs []string
-	}{}
-
-	var qtimodule = fmt.Sprintf("qti_kernel_headers_%s", version)
-
-	p.Export_header_lib_headers = []string{qtimodule}
-	p.Header_libs = []string{qtimodule}
+		Header_libs               []string
+	}{
+		[]string{qtimodule},
+		[]string{qtimodule},
+	}
 
 	ctx.AppendProperties(&p)
 }

--- a/kernel_headers.go
+++ b/kernel_headers.go
@@ -21,16 +21,18 @@ func qtiKernelHeadersDefaultsFactory() android.Module {
 }
 
 func qtiKernelHeadersDefaults(ctx android.LoadHookContext) {
-	version := ctx.Config().VendorConfig("qti_kernel_headers").String("version")
-	qtimodule := fmt.Sprintf("qti_kernel_headers_%s", version)
+	config := ctx.Config().VendorConfig("qti_kernel_headers")
+	if config.IsSet("version") {
+		version := config.String("version")
+		qtimodule := fmt.Sprintf("qti_kernel_headers_%s", version)
 
-	p := struct {
-		Export_header_lib_headers []string
-		Header_libs               []string
-	}{
-		[]string{qtimodule},
-		[]string{qtimodule},
+		p := struct {
+			Export_header_lib_headers []string
+			Header_libs               []string
+		}{
+			[]string{qtimodule},
+			[]string{qtimodule},
+		}
+		ctx.AppendProperties(&p)
 	}
-
-	ctx.AppendProperties(&p)
 }


### PR DESCRIPTION
When building different devices (non-SODP) in the same tree the following error shows up:

	error: kernel/sony/qti-headers/Android.bp:31:1: "qti_kernel_headers" depends on undefined module "qti_kernel_headers_"

As per the documentaition `.String()` on `VendorConfig` returns an empty string if the variable was not set, leading to the `qti_kernel_headers_` name.  Fix this by only reexporting these headers when a version is set.
