### PR TITLE
[master] Mark qti_kernel_headers as recovery_available

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -7,6 +7,8 @@
 // SOONG_CONFIG_NAMESPACES += qti_kernel_headers
 // SOONG_CONFIG_qti_kernel_headers := version
 // SOONG_CONFIG_qti_kernel_headers_version := 4.14
+// or
+// $(call soong_config_set,qti_kernel_headers,version,4.14)
 
 bootstrap_go_package {
     name: "soong-qti_kernel_headers_defaults",

--- a/Android.bp
+++ b/Android.bp
@@ -32,4 +32,5 @@ cc_library_headers {
     name: "qti_kernel_headers",
     defaults: ["qti_kernel_headers_defaults"],
     vendor_available: true,
+    recovery_available: true,
 }

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Needs following changes:
 SOONG_CONFIG_NAMESPACES += qti_kernel_headers
 SOONG_CONFIG_qti_kernel_headers := version
 SOONG_CONFIG_qti_kernel_headers_version := 4.14
+# or
+$(call soong_config_set,qti_kernel_headers,version,4.14)
 ```
 
 `common-headers` needs to rename the module name from `qti_kernel_headers` to


### PR DESCRIPTION
Some future components require the kernel headers to be recovery_available.
```
error: vendor/qcom/opensource/recovery-ext/oem-recovery/Android.bp:25:1:
dependency "qti_kernel_headers" of "librecovery_updater" missing variant:
  os:android,image:recovery,arch:arm64_armv8-2a,sdk
```